### PR TITLE
Set textdomain to apparmor

### DIFF
--- a/package/yast2-apparmor.changes
+++ b/package/yast2-apparmor.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Nov 28 13:21:35 CET 2017 - sbrabec@suse.com
+
+- Set textdomain consistently to apparmor (bsc#1065569).
+- 4.0.2
+
+-------------------------------------------------------------------
 Wed Oct 18 11:11:36 CDT 2017 - rgoldwyn@suse.com
 
 - Remove more perl dependencies (boo#1062656)

--- a/package/yast2-apparmor.spec
+++ b/package/yast2-apparmor.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-apparmor
-Version:        4.0.1
+Version:        4.0.2
 Release:        0
 Summary:        YaST2 - Plugins for AppArmor Profile Management
 Url:            https://github.com/yast/yast-apparmor

--- a/src/clients/apparmor.rb
+++ b/src/clients/apparmor.rb
@@ -25,7 +25,7 @@ module Yast
   class ApparmorClient < Client
     def main
       Yast.import "UI"
-      textdomain "yast2-apparmor"
+      textdomain "apparmor"
       Yast.import "Wizard"
       Yast.import "Label"
       Yast.import "Popup"

--- a/src/include/apparmor/aa-config.rb
+++ b/src/include/apparmor/aa-config.rb
@@ -28,7 +28,7 @@ module Yast
       Yast.include include_target, "apparmor/config_complain.rb"
       Yast.include include_target, "apparmor/helps.rb"
       Yast.include include_target, "apparmor/apparmor_ycp_utils.rb"
-      textdomain "yast2-apparmor"
+      textdomain "apparmor"
 
       Yast.import "Label"
       Yast.import "Popup"

--- a/src/include/apparmor/apparmor_profile_check.rb
+++ b/src/include/apparmor/apparmor_profile_check.rb
@@ -26,7 +26,7 @@ module Yast
     def initialize_apparmor_apparmor_profile_check(include_target)
 
       Yast.import "Popup"
-      textdomain "yast2-apparmor"
+      textdomain "apparmor"
     end
 
     def checkProfileSyntax

--- a/src/include/apparmor/apparmor_ycp_utils.rb
+++ b/src/include/apparmor/apparmor_ycp_utils.rb
@@ -29,7 +29,7 @@ module Yast
       Yast.import "Label"
       Yast.import "Popup"
       Yast.import "AppArmorDialogs"
-      textdomain "yast2-apparmor"
+      textdomain "apparmor"
 
       @CMDS = {}
       Ops.set(@CMDS, "CMD_ALLOW", _("&Allow"))

--- a/src/include/apparmor/capabilities.rb
+++ b/src/include/apparmor/capabilities.rb
@@ -27,7 +27,7 @@
 module Yast
   module ApparmorCapabilitiesInclude
     def initialize_apparmor_capabilities(include_target)
-      textdomain "yast2-apparmor"
+      textdomain "apparmor"
 
       @capdefs = {
         "chown"            => {

--- a/src/include/apparmor/config_complain.rb
+++ b/src/include/apparmor/config_complain.rb
@@ -25,7 +25,7 @@ module Yast
   module ApparmorConfigComplainInclude
     def initialize_apparmor_config_complain(include_target)
       Yast.import "UI"
-      textdomain "yast2-apparmor"
+      textdomain "apparmor"
 
       Yast.import "Label"
       Yast.import "Popup"

--- a/src/include/apparmor/helps.rb
+++ b/src/include/apparmor/helps.rb
@@ -24,7 +24,7 @@
 module Yast
   module ApparmorHelpsInclude
     def initialize_apparmor_helps(include_target)
-      textdomain "yast2-apparmor"
+      textdomain "apparmor"
 
       # START Help Section
       #**********************************************************

--- a/src/include/apparmor/profile_dialogs.rb
+++ b/src/include/apparmor/profile_dialogs.rb
@@ -30,7 +30,7 @@ module Yast
       Yast.import "Label"
       Yast.import "Map"
       Yast.include include_target, "apparmor/capabilities.rb"
-      textdomain "yast2-apparmor"
+      textdomain "apparmor"
 
       # Globalz
       @timeout_millisec = 20 * 1000

--- a/src/modules/AppArmorDialogs.rb
+++ b/src/modules/AppArmorDialogs.rb
@@ -26,7 +26,7 @@ require "yast"
 module Yast
   class AppArmorDialogsClass < Module
     def main
-      textdomain "yast2-apparmor"
+      textdomain "apparmor"
 
       @busy_dialog = nil
     end


### PR DESCRIPTION
Fix textdomain split (yast2-apparmor x apparmor) and consistently use apparmor.
[https://bugzilla.suse.com/show_bug.cgi?id=1065569](url)