### PR TITLE
Process profile change only if we have it selected

### DIFF
--- a/package/yast2-apparmor.changes
+++ b/package/yast2-apparmor.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Aug 24 08:20:53 CDT 2018 - rgoldwyn@suse.com
+
+- Process profile change only if we have it selected (bsc#1090592)
+- 4.1.0
+
+-------------------------------------------------------------------
 Mon Aug 20 16:24:15 CEST 2018 - schubi@suse.de
 
 - Switched license in spec file from SPDX2 to SPDX3 format.

--- a/package/yast2-apparmor.spec
+++ b/package/yast2-apparmor.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-apparmor
-Version:        4.0.5
+Version:        4.1.0
 Release:        0
 Summary:        YaST2 - Plugins for AppArmor Profile Management
 Url:            https://github.com/yast/yast-apparmor

--- a/src/lib/apparmor/profiles.rb
+++ b/src/lib/apparmor/profiles.rb
@@ -159,7 +159,7 @@ module AppArmor
     def changeMode_handler
       selected_item = Yast::UI.QueryWidget(Id(:entries_table), :CurrentItem)
       log.info "Toggling #{selected_item}"
-      @profiles.toggle(selected_item)
+      @profiles.toggle(selected_item) if selected_item
       redraw_table
     end
 


### PR DESCRIPTION
The selected profile is the first in the list. However, if there
are no active profiles, selected_item is nil.
Check for selected_item before toggling the class.

Signed-off-by: Goldwyn Rodrigues <rgoldwyn@suse.com>