### PR TITLE
WIP: More robust aa-status output parser

### DIFF
--- a/src/lib/apparmor/profiles.rb
+++ b/src/lib/apparmor/profiles.rb
@@ -48,7 +48,7 @@ module AppArmor
     end
 
     def to_s
-      @name + ', ' + @status + ', ' + @pid
+      "#{@name}, #{@status}, #{@pid}"
     end
 
     def to_array
@@ -77,22 +77,15 @@ module AppArmor
 
   # Class representing a list of profiles
   class Profiles
+    include Yast::Logger
     attr_reader :prof
     def initialize
-      status_output = command_output("/usr/sbin/aa-status", "--json")
-
-      jtext = JSON.parse(status_output)
-      h = jtext['profiles']
       @prof = {}
-      h.each do |name, status|
-        @prof[name] = Profile.new(name, status)
-      end
-      h = jtext['processes']
-      h.each do |name, pidmap|
-        pidmap.each do |p|
-          @prof[name].addPid(p['pid'])
-        end
-      end
+      status_output = command_output("/usr/sbin/aa-status", "--pretty-json")
+      log.info("aa-status output:\n#{status_output}\n")
+      jtext = JSON.parse(status_output)
+      add_profiles(jtext["profiles"])
+      add_processes(jtext["processes"])
     end
 
     def active
@@ -109,6 +102,68 @@ module AppArmor
     end
 
   private
+
+    # Add all profiles from the "profiles" section of the parsed JSON output of
+    # the aa-status command.
+    #
+    # Sample JSON:
+    #
+    #  "profiles": {
+    #      "/usr/bin/lessopen.sh": "enforce",
+    #      "/usr/lib/colord": "enforce",
+    #      "/usr/{bin,sbin}/dnsmasq": "enforce",
+    #      "nscd": "enforce",
+    #      "ntpd": "enforce",
+    #      "syslogd": "enforce",
+    #      "traceroute": "enforce",
+    #      "winbindd": "enforce"
+    #  }
+    def add_profiles(profiles)
+      return if profiles.nil?
+      profiles.each do |name, status|
+        log.info("Profile name: #{name} status: #{status}")
+        @prof[name] = Profile.new(name, status)
+      end
+    end
+
+    # Add all processesfrom the "profiles" section of the parsed JSON output of
+    # the aa-status command.
+    #
+    # Sample JSON:
+    #
+    # "processes": {
+    #     "/usr/sbin/nscd": [
+    #         {
+    #             "profile": "nscd",
+    #             "pid": "805",
+    #             "status": "enforce"
+    #         }
+    #     ],
+    #     "/usr/lib/colord": [
+    #         {
+    #             "profile": "/usr/lib/colord",
+    #             "pid": "1790",
+    #             "status": "enforce"
+    #         }
+    #     ]
+    # }
+    def add_processes(processes)
+      return if processes.nil?
+      processes.each do |executable_name, pidmap_list|
+        pidmap_list.each do |pidmap|
+          profile_name = pidmap["profile"] || executable_name
+          pid = pidmap["pid"]
+          if @prof.key?(profile_name)
+            msg = "Active process #{pid} #{executable_name}"
+            msg += " profile name #{profile_name}" if executable_name != profile_name
+            log.info(msg)
+            @prof[profile_name].addPid(pid)
+          else
+            log.warn("No profile #{profile_name}")
+          end
+        end
+      end
+    end
 
     # Returns the output of the given command
     #


### PR DESCRIPTION
## Trello

https://trello.com/c/3d3oJxcu/612-1121274-build-20190105-internal-error-when-trying-to-edit-settings-in-yast-apparrmor-module

## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1121274

## Problem

AppArmor profiles can also have a short name, not just the full path of the binary that is confined in AppArmor.

There was a recent change in Tumbleweed that appears to use that more heavily, and the old parser of this YaST AppArmor module was not quite robust enough to handle that; it would not find the correct profile anymore, and it tried to access a nonexistent hash key in the hash of all profiles, resulting in a `nil:NilClass (NoMethodError)` exception.

## Sample JSON output

(taken from the y2logs from the bug and reformatted to human-readable format):

```JSON
{
    "version": "1",
    "profiles": {
        "/usr/bin/lessopen.sh": "enforce",
        "/usr/lib/apache2/mpm-prefork/apache2": "enforce",
        "/usr/lib/apache2/mpm-prefork/apache2//DEFAULT_URI": "enforce",
        "/usr/lib/apache2/mpm-prefork/apache2//HANDLING_UNTRUSTED_INPUT": "enforce",
        "/usr/lib/apache2/mpm-prefork/apache2//phpsysinfo": "enforce",
        "/usr/lib/colord": "enforce",
        "/usr/lib/dovecot/anvil": "enforce",
        "/usr/lib/dovecot/auth": "enforce",
        "/usr/lib/dovecot/config": "enforce",
        "/usr/lib/dovecot/deliver": "enforce",
        "/usr/lib/dovecot/dict": "enforce",
        "/usr/lib/dovecot/dovecot-auth": "enforce",
        "/usr/lib/dovecot/dovecot-lda": "enforce",
        "/usr/lib/dovecot/dovecot-lda//sendmail": "enforce",
        "/usr/lib/dovecot/imap": "enforce",
        "/usr/lib/dovecot/imap-login": "enforce",
        "/usr/lib/dovecot/lmtp": "enforce",
        "/usr/lib/dovecot/log": "enforce",
        "/usr/lib/dovecot/managesieve": "enforce",
        "/usr/lib/dovecot/managesieve-login": "enforce",
        "/usr/lib/dovecot/pop3": "enforce",
        "/usr/lib/dovecot/pop3-login": "enforce",
        "/usr/lib/dovecot/ssl-params": "enforce",
        "/usr/lib/dovecot/stats": "enforce",
        "/usr/{bin,sbin}/dnsmasq": "enforce",
        "/usr/{bin,sbin}/dnsmasq//libvirt_leaseshelper": "enforce",
        "apache2": "enforce",
        "apache2//DEFAULT_URI": "enforce",
        "apache2//HANDLING_UNTRUSTED_INPUT": "enforce",
        "apache2//phpsysinfo": "enforce",
        "avahi-daemon": "enforce",
        "dovecot": "enforce",
        "identd": "enforce",
        "klogd": "enforce",
        "mdnsd": "enforce",
        "nmbd": "enforce",
        "nscd": "enforce",
        "ntpd": "enforce",
        "nvidia_modprobe": "enforce",
        "nvidia_modprobe//kmod": "enforce",
        "ping": "enforce",
        "smbd": "enforce",
        "smbldap-useradd": "enforce",
        "smbldap-useradd///etc/init.d/nscd": "enforce",
        "syslog-ng": "enforce",
        "syslogd": "enforce",
        "traceroute": "enforce",
        "winbindd": "enforce"
    },
    "processes": {
        "/usr/sbin/nscd": [
            {
                "profile": "nscd",
                "pid": "805",
                "status": "enforce"
            }
        ],
        "/usr/sbin/avahi-daemon": [
            {
                "profile": "avahi-daemon",
                "pid": "806",
                "status": "enforce"
            }
        ],
        "/usr/lib/colord": [
            {
                "profile": "/usr/lib/colord",
                "pid": "1790",
                "status": "enforce"
            }
        ]
    }
}
```

Notice the entries for `nscd`:

```
{
    "profiles": {
        ...
        "nscd": "enforce",
        ...
    },
    "processes": {
        "/usr/sbin/nscd": [
            {
                "profile": "nscd",
                "pid": "805",
                "status": "enforce"
            }
        ],
        ...
   }
}
```

In `profiles` the name is just `nscd`. In `processes` there is an entry for the `/usr/sbin/nscd` executable, but the corresponding profile name is in `profile` in the hash in the list of processes.

In the profile,