### PR TITLE
Permit new aa-status parser also for one earlier aa-status version

### DIFF
--- a/package/yast2-apparmor.changes
+++ b/package/yast2-apparmor.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jan 28 13:16:50 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Permit new aa-status parser also for one earlier aa-status version
+  (bsc#1123258)
+- 4.1.6
+
+-------------------------------------------------------------------
 Thu Jan 24 12:39:46 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Adapted aa-status parser to new output format to prevent crash

--- a/package/yast2-apparmor.spec
+++ b/package/yast2-apparmor.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-apparmor
-Version:        4.1.5
+Version:        4.1.6
 Release:        0
 Summary:        YaST2 - Plugins for AppArmor Profile Management
 Url:            https://github.com/yast/yast-apparmor
@@ -33,8 +33,8 @@ Requires:       yast2-ruby-bindings >= 1.0.0
 
 # New JSON output format in aa-status; upstream change:
 # aa-status: split profile from exec name
-# bsc#1121274 / PR#35
-Conflicts:	apparmor-utils < 2.13
+# bsc#1121274 / PR#35, bsc#1123258 / PR#36
+Conflicts:	apparmor-utils < 2.12
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1121274

## Problem

SLE-15 SP1 does not have apparmor*-2.13 yet, it's still 2.12.

Since we did not split off YaST development for a separate SLE-15 SP1 branch yet, the latest Factory / TW submission also automatically went to SLE-15 SP1 and caused a dependency conflict there:

```
yast2-apparmor-4.1.5-1.2.noarch conflicts with apparmor-utils < 2.13
```

## Fix

Relaxed the dependency check; now also allowing that latest yast2-apparmor package to peacefully coexist with the next older apparmor-utils version 2.12.

The parser is robust enough to understand both formats; if there is no explicit profile name for each of the running processes, it will fall back to the executable name which is there in both JSON versions.

## Details

### Expected new JSON format:

```
% rpm -q apparmor-utils
apparmor-utils-2.13.2-3.1.noarch

% sudo aa-status --pretty-json

{
    "version": "1",
    "profiles": {
        "/usr/bin/lessopen.sh": "enforce",
        "dovecot": "enforce",
        ...
        "nscd": "enforce",
        "ntpd": "enforce",
        ...
    },
    "processes": {
        "/usr/sbin/nscd": [
            {
                "profile": "nscd",
                "pid": "805",
                "status": "enforce"
            }
        ],
        "/usr/sbin/avahi-daemon": [
            {
                "profile": "avahi-daemon",
                "pid": "806",
                "status": "enforce"
            }
        ],
        "/usr/lib/colord": [
            {
                "profile": "/usr/lib/colord",
                "pid": "1790",
                "status": "enforce"
            }
        ]
    }
}
```

### Old JSON format:

```
% rpm -q apparmor-utils
apparmor-utils-2.12-7.6.2.noarch

% sudo aa-status --pretty-json

{
    "processes": {
        "/usr/sbin/nscd": [
            {
                "pid": "722",
                "status": "enforce"
            }
        ]
    },
    "profiles": {
        "/usr/bin/lessopen.sh": "enforce",
        ...
        "/usr/sbin/nscd": "enforce",
        "/usr/sbin/ntpd": "enforce",
        ...
    },
    "version": "1"
}
```

This works because if the "profile" key is not present in each of the entries in "processes", it falls back to the executable name ("/usr/bin/nscd" in this case):

https://github.com/yast/yast-apparmor/blob/master/src/lib/apparmor/profiles.rb#L154

```Ruby
profile_name = pidmap["profile"] || executable_name
```

I.e. if `pidmap["profile"]` is `nil` (i.e. there is no hash key `profile`), use `executable_name` instead which was the hash key one level earlier that is iterated over in the outer loop.