### PR TITLE
Implemented "Changes" dialog

### DIFF
--- a/package/yast2-apparmor.changes
+++ b/package/yast2-apparmor.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Jan 30 15:51:08 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Implemented "changes" dialog for "scan audit logs" (bsc#1120043)
+- Properly line up radio buttons
+- Allow to translate "OK" button
+- 4.1.7
+
+-------------------------------------------------------------------
 Mon Jan 28 13:16:50 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Permit new aa-status parser also for one earlier aa-status version

--- a/package/yast2-apparmor.spec
+++ b/package/yast2-apparmor.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-apparmor
-Version:        4.1.6
+Version:        4.1.7
 Release:        0
 Summary:        YaST2 - Plugins for AppArmor Profile Management
 Url:            https://github.com/yast/yast-apparmor

--- a/src/lib/apparmor/apparmor_ui_dialog.rb
+++ b/src/lib/apparmor/apparmor_ui_dialog.rb
@@ -214,10 +214,10 @@ module AppArmor
       return box if @options.nil?
       @options.each_with_index do |opt, i|
         log.info "opt #{opt} i #{i}"
-        box << RadioButton(Id(i.to_s), opt.to_s, i == 0)
+        box << Left(RadioButton(Id(i.to_s), opt.to_s, i == 0))
         box << VSpacing(1)
       end
-      VBox(RadioButtonGroup(Id(:options), box))
+      VBox(RadioButtonGroup(Id(:options), HSquash(box)))
     end
 
     def menu_to_text_key(menu)

--- a/src/lib/apparmor/apparmor_ui_dialog.rb
+++ b/src/lib/apparmor/apparmor_ui_dialog.rb
@@ -125,7 +125,7 @@ module AppArmor
 	  VSpacing(0.3),
           InputField(Id(:str), Opt(:hstretch), @text, @default),
 	  VSpacing(0.3),
-          PushButton('&OK')
+          PushButton(Label.OKButton)
         )
       )
       Yast::UI.UserInput()


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1120043

## Trello

https://trello.com/c/ouTUYF28/647-sles15-sp1-p2-1120043-sle15-sp1-yast-apparmor-module-scan-audit-logs-failed-on-view-changes

## Problem

aa-logprof now has an option "view changes" which shows the diff between the old and the new profile. This was not implemented in the yast2-apparmor module, so the JSON command to execute that dialog resulted in an internal error.

## Fix

Implemented that dialog.

## Limitations

Usability leaves to be desired. There is only an "OK" button in that dialog, not the other options to save the profile, to diff against the last version of the profile or against an empty profile, to abort everything.

Those options are presented in the previous dialog (from which two of the options lead to this dialog) and again in the next dialog. That's just how that JSON protocol with the `aa-logprof` utility works. In the non-JSON interactive mode, selecting the "changes" option shows the diff with "less", and the only thing the user can do from there is to quit "less" and get back to the same menu where he started from; i.e. it behaves the exact same way in the interactive shell mode and in JSON mode (which is expected, of course).

Bottom line: This is as far as we can go with the current tools.

## Screen Shot

![yast2-apparmor-changes](https://user-images.githubusercontent.com/11538225/51994074-56c36200-24b0-11e9-99a2-a6f8c72e3087.png)

The widget showing the diff is a RichText widget in plainText mode, i.e. it can scroll in both dimensions if the texts get larger.

## Bonus Fix: Radio Buttons Alignment

![yast2-apparmor-radio-buttons](https://user-images.githubusercontent.com/11538225/51994098-617df700-24b0-11e9-93ae-895bde72fbb7.png)

When multiple options are presented to choose from, they all used to be centered, i.e. the radio buttons were not lined up, making it hard to see that those are options on the same level. This is now fixed.

I guess the original authors of this module tried something similar, but did not use a HSquash widget, so they were lined up all the way to the left which looks really ugly. The HSquash "squeezes" the extra space out so the entire block does not get any wider than the widest of the options, yet they are all left-aligned to the same level -- which is what users expect.

## Test Procedure

This needs a new AppArmor profile that is in "complain" mode and some complaints in the system logs.

The easiest way to achieve that is to copy an existing program that accesses some files, generate an empty profile for it and let it run a couple of times.

I used a copy of the `/usr/bin/file` command:

```
sudo cp /usr/bin/file /usr/local/bin/aa-test-01
```

Generate an empty AppArmor profile for that command:

```
sudo aa-genprof /usr/local/bin/aa-test-01
```
(exit with "F" for "finish")
This generates `/etc/apparmor.d/usr.local.bin.aa-test-01`.

Set that profile to "complain" mode (otherwise each file access that it tries will automatically be denied):

```
sudo aa-complain /usr/local/bin/aa-test-01
```

Now execute the new command a couple of times with different arguments so AppArmor has something to complain about:

```
aa-test-01 /etc/fstab
aa-test-01 /bin/bash
aa-test-01 /usr/bin/ls
```

You can check if that really did lead to complaints with `sudo aa-logprof` in interactive shell mode, but don't save any changes there just yet.

Now start the YaST AppArmor module and launch the "Scan Audit logs" submodule:

```
sudo yast2 apparmor
```

Click through the workflow, accept some (or all) of the suggested changes, and in the last dialog where there is the "view changes" option, select that. You should get the "changes" dialog.

Notice that the complaints are no longer shown once the changed profile is saved, so for repeated tests you might want to avoid saving the changes.

## Tested Releases

- latest Tumbleweed
- SLE-15 SP1