### PR TITLE
More Robust aa-status Output Parser (bsc#1132418)

### DIFF
--- a/package/yast2-apparmor.changes
+++ b/package/yast2-apparmor.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Nov  7 12:49:56 UTC 2019 - Steffen Winterfeldt <snwint@suse.com>
+
+- Adapted aa-status parser to new output format to prevent crash
+  (bsc#1121274, bsc#1123258, bsc#1132418)
+- 4.0.6
+
+-------------------------------------------------------------------
 Thu Jun 28 16:00:46 CEST 2018 - schubi@suse.de
 
 - Added additional searchkeys to desktop file (fate#321043).

--- a/package/yast2-apparmor.spec
+++ b/package/yast2-apparmor.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-apparmor
-Version:        4.0.5
+Version:        4.0.6
 Release:        0
 Summary:        YaST2 - Plugins for AppArmor Profile Management
 Url:            https://github.com/yast/yast-apparmor
@@ -29,6 +29,9 @@ BuildRequires:  yast2
 BuildRequires:  yast2-devtools >= 3.1.10
 Requires:       yast2
 Requires:       yast2-ruby-bindings >= 1.0.0
+
+# bsc#1121274 / PR#35, bsc#1123258 / PR#36
+Conflicts:      apparmor-utils < 2.12
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch

--- a/src/lib/apparmor/profiles.rb
+++ b/src/lib/apparmor/profiles.rb
@@ -6,6 +6,8 @@
 require 'json'
 require 'open3'
 require 'yast'
+require "yast2/execute"
+
 Yast.import 'UI'
 Yast.import 'Label'
 Yast.import 'Popup'
@@ -23,13 +25,13 @@ module AppArmor
 
     # Set to complain mode
     def complain
-      system("/usr/sbin/aa-complain #{@name}")
+      execute("/usr/sbin/aa-complain", @name)
       @status = 'complain'
     end
 
     # Set to enforce mode
     def enforce
-      system("/usr/sbin/aa-enforce #{@name}")
+      execute("/usr/sbin/aa-enforce", @name)
       @status = 'enforce'
     end
 
@@ -46,7 +48,7 @@ module AppArmor
     end
 
     def to_s
-      @name + ', ' + @status + ', ' + @pid
+      "#{@name}, #{@status}, #{@pid}"
     end
 
     def to_array
@@ -57,25 +59,33 @@ module AppArmor
       a.push(pstr)
       a
     end
+
+  private
+
+    # Executes a given command
+    #
+    # For possible parameters, see Yast::Execute.locally!.
+    #
+    # @return [Boolean] true if the command finishes correctly; false otherwise
+    def execute(*args)
+      Yast::Execute.locally!(*args)
+      true
+    rescue Cheetah::ExecutionFailed
+      false
+    end
   end
 
   # Class representing a list of profiles
   class Profiles
+    include Yast::Logger
     attr_reader :prof
     def initialize
-      status_output = `/usr/sbin/aa-status --json`
-      jtext = JSON.parse(status_output)
-      h = jtext['profiles']
       @prof = {}
-      h.each do |name, status|
-        @prof[name] = Profile.new(name, status)
-      end
-      h = jtext['processes']
-      h.each do |name, pidmap|
-        pidmap.each do |p|
-          @prof[name].addPid(p['pid'])
-        end
-      end
+      status_output = command_output("/usr/sbin/aa-status", "--pretty-json")
+      log.info("aa-status output:\n#{status_output}\n")
+      jtext = JSON.parse(status_output)
+      add_profiles(jtext["profiles"])
+      add_processes(jtext["processes"])
     end
 
     def active
@@ -89,6 +99,82 @@ module AppArmor
 
     def toggle(name)
       @prof[name].toggle
+    end
+
+  private
+
+    # Add all profiles from the "profiles" section of the parsed JSON output of
+    # the aa-status command.
+    #
+    # Sample JSON:
+    #
+    #  "profiles": {
+    #      "/usr/bin/lessopen.sh": "enforce",
+    #      "/usr/lib/colord": "enforce",
+    #      "/usr/{bin,sbin}/dnsmasq": "enforce",
+    #      "nscd": "enforce",
+    #      "ntpd": "enforce",
+    #      "syslogd": "enforce",
+    #      "traceroute": "enforce",
+    #      "winbindd": "enforce"
+    #  }
+    def add_profiles(profiles)
+      return if profiles.nil?
+      profiles.each do |name, status|
+        log.info("Profile name: #{name} status: #{status}")
+        @prof[name] = Profile.new(name, status)
+      end
+    end
+
+    # Add all processesfrom the "profiles" section of the parsed JSON output of
+    # the aa-status command.
+    #
+    # Sample JSON:
+    #
+    # "processes": {
+    #     "/usr/sbin/nscd": [
+    #         {
+    #             "profile": "nscd",
+    #             "pid": "805",
+    #             "status": "enforce"
+    #         }
+    #     ],
+    #     "/usr/lib/colord": [
+    #         {
+    #             "profile": "/usr/lib/colord",
+    #             "pid": "1790",
+    #             "status": "enforce"
+    #         }
+    #     ]
+    # }
+    def add_processes(processes)
+      return if processes.nil?
+      processes.each do |executable_name, pidmap_list|
+        pidmap_list.each do |pidmap|
+          profile_name = pidmap["profile"] || executable_name
+          pid = pidmap["pid"]
+          if @prof.key?(profile_name)
+            msg = "Active process #{pid} #{executable_name}"
+            msg += " profile name #{profile_name}" if executable_name != profile_name
+            log.info(msg)
+            @prof[profile_name].addPid(pid)
+          else
+            log.warn("No profile #{profile_name}")
+          end
+        end
+      end
+    end
+
+    # Returns the output of the given command
+    #
+    # @param args [Array<String>, Array<Array<String>>] the command to execute and
+    #   its arguments. For a detailed description, see
+    #   https://www.rubydoc.info/github/openSUSE/cheetah/Cheetah#run-class_method
+    # @return [String] commmand output or an empty string if the command fails.
+    def command_output(*args)
+      Yast::Execute.locally!(*args, stdout: :capture)
+    rescue Cheetah::ExecutionFailed
+      ""
     end
   end
 
@@ -159,7 +245,7 @@ module AppArmor
     def changeMode_handler
       selected_item = Yast::UI.QueryWidget(Id(:entries_table), :CurrentItem)
       log.info "Toggling #{selected_item}"
-      @profiles.toggle(selected_item)
+      @profiles.toggle(selected_item) if selected_item
       redraw_table
     end
 


### PR DESCRIPTION
## Problem

A backport of https://github.com/yast/yast-apparmor/pull/35 to SLE-15-GA is wanted.

For more context read the above pull request.

- Bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1132418
- Scrum card: https://trello.com/c/VjxuDlca

## Solution

Bring `profiles.rb` to the version currently in the SLE-15-SP1 branch.

Basically https://github.com/yast/yast-apparmor/pull/35 + some changes switching to using cheetah to run commands.