### PR TITLE
Replace rclink

### DIFF
--- a/package/yast2-apparmor.changes
+++ b/package/yast2-apparmor.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jan 13 13:35:12 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
+
+- replace rcsymlink by direct systemd call (jsc#SLE-10976)
+- 4.2.2
+
+-------------------------------------------------------------------
 Fri May 31 12:25:09 UTC 2019 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Add metainfo (fate#319035)

--- a/package/yast2-apparmor.spec
+++ b/package/yast2-apparmor.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-apparmor
-Version:        4.2.1
+Version:        4.2.2
 Release:        0
 Summary:        YaST2 - Plugins for AppArmor Profile Management
 Url:            https://github.com/yast/yast-apparmor

--- a/src/include/apparmor/config_complain.rb
+++ b/src/include/apparmor/config_complain.rb
@@ -210,7 +210,7 @@ module Yast
             ret = Convert.to_integer(
               SCR.Execute(
                 path(".target.bash"),
-                "/sbin/rcapparmor reload > /dev/null 2>&1"
+                "/bin/systemctl reload apparmor"
               )
             )
           else


### PR DESCRIPTION
trello: https://trello.com/c/Cx9X2roJ/1472-3-get-rid-of-etc-initd-and-sbin-rc-calls

motivation preparation for dropping of init.d and rc symlinks and use systemctl everywhere.