### PR TITLE
don't use /bin/systemctl compat symlink (bsc#1160890)

### DIFF
--- a/package/yast2-apparmor.changes
+++ b/package/yast2-apparmor.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jan 23 12:41:07 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
+
+- don't use /bin/systemctl compat symlink (bsc#1160890)
+- 4.2.3
+
+-------------------------------------------------------------------
 Mon Jan 13 13:35:12 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - replace rcsymlink by direct systemd call (jsc#SLE-10976)

--- a/package/yast2-apparmor.spec
+++ b/package/yast2-apparmor.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-apparmor
-Version:        4.2.2
+Version:        4.2.3
 Release:        0
 Summary:        YaST2 - Plugins for AppArmor Profile Management
 Url:            https://github.com/yast/yast-apparmor

--- a/src/include/apparmor/config_complain.rb
+++ b/src/include/apparmor/config_complain.rb
@@ -210,7 +210,7 @@ module Yast
             ret = Convert.to_integer(
               SCR.Execute(
                 path(".target.bash"),
-                "/bin/systemctl reload apparmor"
+                "/usr/bin/systemctl reload apparmor"
               )
             )
           else


### PR DESCRIPTION
## Problem

https://bugzilla.suse.com/show_bug.cgi?id=1160890
https://trello.com/c/3Y9HSV8m

`/bin/systemctl` symlink is gone.

## Solution

Don't use it.