### PR TITLE
Fixed user-visible messages (bsc#1084015)

### DIFF
--- a/package/yast2-apparmor.changes
+++ b/package/yast2-apparmor.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Feb 17 16:01:12 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Fixed user-visible messages (bsc#1084015)
+- 4.2.4
+
+-------------------------------------------------------------------
 Thu Jan 23 12:41:07 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
 
 - don't use /bin/systemctl compat symlink (bsc#1160890)

--- a/package/yast2-apparmor.spec
+++ b/package/yast2-apparmor.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-apparmor
-Version:        4.2.3
+Version:        4.2.4
 Release:        0
 Summary:        YaST2 - Plugins for AppArmor Profile Management
 Url:            https://github.com/yast/yast-apparmor

--- a/src/include/apparmor/profile_dialogs.rb
+++ b/src/include/apparmor/profile_dialogs.rb
@@ -1490,7 +1490,8 @@ module Yast
         end
         if id == :abort || id == :cancel
           break
-        # This module break common work-flow that changes are commited at the end, so react same for break and also for next
+        # This module breaks the common YaST workflow rule that changes are
+        # commited at the end, so react the same way for back and also for next
         elsif id == :back || id == :next
           break
         else

--- a/src/include/apparmor/profile_dialogs.rb
+++ b/src/include/apparmor/profile_dialogs.rb
@@ -1478,7 +1478,7 @@ module Yast
           end # TODO ELSE POPUP NO ENTRY SELECTED ERROR
         elsif id == :delete
           # Translators: %1 is the name of the profile.
-          popup_msg = Builtins.sformat(_("Are you sure you want to delete the profile \"%1\"?"), profilename )
+          popup_msg = Builtins.sformat(_("Are you sure you want to delete the profile\n\"%1\"?"), profilename )
           popup_msg += "\n" + _("After this operation the AppArmor module will reload the profile set.")
           if Popup.YesNoHeadline(_("Delete profile confirmation"), popup_msg)
             Builtins.y2milestone("Deleted %1", profilename)

--- a/src/include/apparmor/profile_dialogs.rb
+++ b/src/include/apparmor/profile_dialogs.rb
@@ -1477,19 +1477,11 @@ module Yast
             next
           end # TODO ELSE POPUP NO ENTRY SELECTED ERROR
         elsif id == :delete
-          if Popup.YesNoHeadline(
-              _("Delete profile confirmation"),
-              Ops.add(
-                Ops.add(
-                  _("Are you sure you want to delete the profile "),
-                  profilename
-                ),
-                _(
-                  " ?\nAfter this operation the AppArmor module will reload the profile set."
-                )
-              )
-            )
-            Builtins.y2milestone(Ops.add("Deleted ", profilename))
+          # Translators: %1 is the name of the profile.
+          popup_msg = Builtins.sformat(_("Are you sure you want to delete the profile \"%1\"?"), profilename )
+          popup_msg += "\n" + _("After this operation the AppArmor module will reload the profile set.")
+          if Popup.YesNoHeadline(_("Delete profile confirmation"), popup_msg)
+            Builtins.y2milestone("Deleted %1", profilename)
             result = SCR.Write(path(".apparmor_profiles.delete"), profilename)
             result2 = SCR.Execute(path(".target.bash"), "/sbin/apparmor_parser -r /etc/apparmor.d")
           end


### PR DESCRIPTION
## Bugzilla 

https://bugzilla.suse.com/show_bug.cgi?id=1084015


## Description

This puts en_US "translations" which are really fixes for broken English or broken translations back into the sources.

This PR is a bit special: The original authors of this code (the ex-AppArmor team before the company was acquired by Novell) did not properly format variables to put them into the message; rather, they just used the string `+` operator to put the string together from pieces. Ouch.


## Test

I could not test this code.

_In god^WopenQA we trust._ :smile: 
