### PR TITLE
Fixed menu navigation using arrow keys in Qt UI (bsc#1172035)

### DIFF
--- a/package/yast2-apparmor.changes
+++ b/package/yast2-apparmor.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Oct 12 13:54:06 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed menu navigation using arrow keys in Qt UI - do not start
+  the selected module immediately after changing the selection
+  (bsc#1172035)
+- 4.3.1
+
+-------------------------------------------------------------------
 Fri Sep 25 10:02:31 CEST 2020 - schubi@suse.de
 
 - Adaptions to AppArmor 3.X: Changes in AppArmor aa-status output.

--- a/package/yast2-apparmor.spec
+++ b/package/yast2-apparmor.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-apparmor
-Version:        4.3.0
+Version:        4.3.1
 Release:        0
 Summary:        YaST2 - Plugins for AppArmor Profile Management
 Url:            https://github.com/yast/yast-apparmor

--- a/src/clients/apparmor.rb
+++ b/src/clients/apparmor.rb
@@ -93,22 +93,24 @@ module Yast
 
       ret = nil
       while true
-        ret = UI.UserInput
+        event = UI.WaitForEvent
+        ret = event["ID"]
+        Builtins.y2milestone("Input event: %1", event)
 
         # abort?
         if ret == :abort || ret == :cancel
           break
-        # next
-        elsif ret == :next || ret == :modules
+        # next or selecting an item,
+        # differ between changing the current item and activating it
+        elsif ret == :next || (ret == :modules && event["EventReason"] == "Activated")
           # check_*
           ret = :next
           break
         # back
         elsif ret == :back
           break
-        else
+        elsif ret != :modules
           Builtins.y2error("unexpected retcode: %1", ret)
-          next
         end
       end
 


### PR DESCRIPTION
## The Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1172035
- The selected module was started immediately after changing the selection using the arrow keys.

## The Solution

- We need to differ between the selection changed and item activated events, for that we need to switch to the `UI.WaitForEvent` which provides more details than the `UI.UserInput`.

## Testing

- Tested manually in both Qt and ncurses UI, in both you can navigate in the list using the arrow keys, pressing `Enter` starts the selected module.