### PR TITLE
Added Missing textdomain [SLE-15-SP4]

### DIFF
--- a/package/yast2-apparmor.changes
+++ b/package/yast2-apparmor.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jun  5 08:19:51 UTC 2023 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Added missing textdomain (bsc#1211980)
+- 4.4.2
+
+-------------------------------------------------------------------
 Mon May 24 14:49:39 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not crash when the profiles list is empty (bsc#1186330).

--- a/package/yast2-apparmor.spec
+++ b/package/yast2-apparmor.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-apparmor
-Version:        4.4.1
+Version:        4.4.2
 Release:        0
 Summary:        YaST2 - Plugins for AppArmor Profile Management
 Url:            https://github.com/yast/yast-apparmor

--- a/src/lib/apparmor/profiles.rb
+++ b/src/lib/apparmor/profiles.rb
@@ -80,6 +80,7 @@ module AppArmor
 
     attr_reader :prof
     def initialize
+      textdomain "apparmor"
       @prof = {}
       status_output = command_output("/usr/sbin/aa-status", "--pretty-json")
       log.info("aa-status output:\n#{status_output}\n")


### PR DESCRIPTION
## Target Branch

**This is for _SLE-15-SP4_**. A merge to SLE-15-SP5 and _master_ / _Factory_ will follow.


## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1211980


## Trello

https://trello.com/c/XAXbqQwE


## Problem

In a rare error case, the YaST AppArmor module wants to report the error to the user, but that fails because the constructor of that class does not have a `textdomain` call prior to using the `_(...)` translation method.


## Fix

Added that missing `textdomain` call.


## Related PRs

- Merge to _SLE-15-SP5_: _TBD_
- Merge to _master_: _TBD_