### PR TITLE
Fixed crash on internal error when scanning audit.log

### DIFF
--- a/package/yast2-apparmor.changes
+++ b/package/yast2-apparmor.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Aug 22 08:03:15 UTC 2023 - Michal Filka <mfilka@suse.com>
+
+- bsc#1214418
+  - Fixed crash on internal error when scanning audit.log
+- 4.6.2
+
+-------------------------------------------------------------------
 Mon Jun  5 08:19:51 UTC 2023 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Added missing textdomain (bsc#1211980)

--- a/package/yast2-apparmor.spec
+++ b/package/yast2-apparmor.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-apparmor
-Version:        4.6.1
+Version:        4.6.2
 Release:        0
 Summary:        YaST2 - Plugins for AppArmor Profile Management
 Url:            https://github.com/yast/yast-apparmor

--- a/src/lib/apparmor/apparmor_ui_dialog.rb
+++ b/src/lib/apparmor/apparmor_ui_dialog.rb
@@ -125,7 +125,7 @@ module AppArmor
 	  VSpacing(0.3),
           InputField(Id(:str), Opt(:hstretch), @text, @default),
 	  VSpacing(0.3),
-          PushButton(Label.OKButton)
+          PushButton(Yast::Label.OKButton)
         )
       )
       Yast::UI.UserInput()


### PR DESCRIPTION
## Problem

Precondition: make sure you have an "exec" event in your audit.log, for example by adding the following (made-up) line to your /var/log/audit/audit.log:

type=AVC msg=audit(1692535178.922:9306963): apparmor="ALLOWED" operation="exec" class="file" profile="ping" name="/usr/bin/cat" pid=25489 comm="hello" requested_mask="x" denied_mask="x" fsuid=1000 ouid=0 target="ping//null-/usr/bin/cat"


Then
- start yast2 apparmor
- select "Scan Audit logs"
- click "Launch"
- when asked for the execute mode, choose "Named"
- in the following dialog ("transition to local profile?), click "yes"

[bsc#1214418](https://bugzilla.suse.com/show_bug.cgi?id=1214418)

## Solution

Added forgotten namespace identifier


## Testing

- *Tested manually*

