### PR TITLE
Backport sp6

### DIFF
--- a/package/yast2-apparmor.changes
+++ b/package/yast2-apparmor.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Sep 04 08:03:15 UTC 2023 - Michal Filka <mfilka@suse.com>
+
+- bsc#1214418
+  - Backport: Fixed crash on internal error when scanning audit.log
+- 4.6.3
+
+-------------------------------------------------------------------
 Fri Sep 01 19:57:03 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Branch package for SP6 (bsc#1208913)

--- a/package/yast2-apparmor.spec
+++ b/package/yast2-apparmor.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-apparmor
-Version:        4.6.0
+Version:        4.6.3
 Release:        0
 Summary:        YaST2 - Plugins for AppArmor Profile Management
 Url:            https://github.com/yast/yast-apparmor

--- a/src/lib/apparmor/apparmor_ui_dialog.rb
+++ b/src/lib/apparmor/apparmor_ui_dialog.rb
@@ -125,7 +125,7 @@ module AppArmor
 	  VSpacing(0.3),
           InputField(Id(:str), Opt(:hstretch), @text, @default),
 	  VSpacing(0.3),
-          PushButton(Label.OKButton)
+          PushButton(Yast::Label.OKButton)
         )
       )
       Yast::UI.UserInput()


### PR DESCRIPTION
## Problem

There are two changes in 4.6.X for apparmor. One is missing textdomain that was also done for SP5 branch and then crash fix that is in master only, but makes sense for SP6.


## Solution

backport crash fix and bump version to 4.6.3 to avoid collision with 4.6.2 in #62.