### PR TITLE
Remove nscd-related Code

### DIFF
--- a/package/yast2-apparmor.changes
+++ b/package/yast2-apparmor.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jan 28 09:59:39 UTC 2025 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Removed nscd-related code (bsc#1236308)
+- 5.0.1
+
+-------------------------------------------------------------------
 Wed Aug 30 20:16:10 UTC 2023 - Josef Reidinger <jreidinger@suse.cz>
 
 - 5.0.0 (bsc#1185510)

--- a/package/yast2-apparmor.spec
+++ b/package/yast2-apparmor.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-apparmor
-Version:        5.0.0
+Version:        5.0.1
 Release:        0
 Summary:        YaST2 - Plugins for AppArmor Profile Management
 Url:            https://github.com/yast/yast-apparmor

--- a/src/lib/apparmor/profiles.rb
+++ b/src/lib/apparmor/profiles.rb
@@ -121,7 +121,6 @@ module AppArmor
     #      "/usr/bin/lessopen.sh": "enforce",
     #      "/usr/lib/colord": "enforce",
     #      "/usr/{bin,sbin}/dnsmasq": "enforce",
-    #      "nscd": "enforce",
     #      "ntpd": "enforce",
     #      "syslogd": "enforce",
     #      "traceroute": "enforce",
@@ -141,9 +140,9 @@ module AppArmor
     # Sample JSON:
     #
     # "processes": {
-    #     "/usr/sbin/nscd": [
+    #     "/usr/sbin/foo": [
     #         {
-    #             "profile": "nscd",
+    #             "profile": "foo",
     #             "pid": "805",
     #             "status": "enforce"
     #         }


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1236308


## Trello

https://trello.com/c/3Auiiwx8/


## Problem

`nscd` is now dropped from _Factory_ / _Tumbleweed_. YaST should not do any `nscd`-related actions anymore.

### GitHub Search

https://github.com/search?q=org%3Ayast+nscd+language%3APerl&type=code&l=Perl

https://github.com/search?q=org%3Ayast+nscd+language%3ARuby&type=code&l=Ruby


## Fix

Remove all code in sources and tests that refers to `nscd`, no matter if it's about the package, the system user account, or the user group, so future GitHub searches in YaST code will no longer get any hits for the `nscd` search term.

## Affected Branches / Products

Only _Factory_ / _Tumbleweed_.


## Related PRs

- https://github.com/yast/yast-users/pull/400
- https://github.com/yast/yast-services-manager/pull/220